### PR TITLE
Adjusted procurement and processing form fields

### DIFF
--- a/app/(dashboard)/processing-batches/add/components/first-stage-details-step.tsx
+++ b/app/(dashboard)/processing-batches/add/components/first-stage-details-step.tsx
@@ -115,7 +115,7 @@ export function FirstStageDetailsStep() {
                   <Label htmlFor="processMethod">Process Method</Label>
                   <Select
                     onValueChange={field.onChange}
-                    defaultValue={field.value}
+                    value={field.value || ""}
                   >
                     <FormControl>
                       <SelectTrigger id="processMethod">

--- a/app/(dashboard)/processing-batches/add/components/select-criteria-step.tsx
+++ b/app/(dashboard)/processing-batches/add/components/select-criteria-step.tsx
@@ -137,7 +137,7 @@ export function SelectCriteriaStep() {
                     <Input
                       id="lotNo"
                       type="number"
-                      placeholder="Enter lot number"
+                      placeholder="Enter lot number (1, 2, or 3)"
                       value={
                         field.value === null || field.value === undefined
                           ? ""
@@ -145,13 +145,12 @@ export function SelectCriteriaStep() {
                       }
                       onChange={(e) => {
                         const val = e.target.value;
-                        field.onChange(
-                          val === ""
-                            ? null
-                            : isNaN(parseInt(val, 4))
-                              ? null
-                              : parseInt(val, 4)
-                        );
+                        if (val === "") {
+                          field.onChange(null);
+                        } else {
+                          const num = parseInt(val, 10);
+                          field.onChange(isNaN(num) ? null : num);
+                        }
                       }}
                     />
                   </FormControl>

--- a/app/(dashboard)/processing-batches/components/dialogs/add-drying-dialog.tsx
+++ b/app/(dashboard)/processing-batches/components/dialogs/add-drying-dialog.tsx
@@ -366,22 +366,18 @@ export function AddDryingDialog({
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {existingDryingEntries.map(
-                    (
-                      entry // Should already be sorted by day 'asc' from action
-                    ) => (
-                      <TableRow key={entry.id}>
-                        <TableCell>{entry.day}</TableCell>
-                        <TableCell>{entry.temperature}°C</TableCell>
-                        <TableCell>{entry.humidity}%</TableCell>
-                        <TableCell>{entry.pH}</TableCell>
-                        <TableCell>{entry.moisturePercentage}%</TableCell>
-                        <TableCell className="text-right">
-                          {entry.currentQuantity.toFixed(2)}kg
-                        </TableCell>
-                      </TableRow>
-                    )
-                  )}
+                  {existingDryingEntries.map((entry) => (
+                    <TableRow key={entry.id}>
+                      <TableCell>{entry.day}</TableCell>
+                      <TableCell>{entry.temperature}°C</TableCell>
+                      <TableCell>{entry.humidity}%</TableCell>
+                      <TableCell>{entry.pH}</TableCell>
+                      <TableCell>{entry.moisturePercentage}%</TableCell>
+                      <TableCell className="text-right">
+                        {entry.currentQuantity.toFixed(2)}kg
+                      </TableCell>
+                    </TableRow>
+                  ))}
                 </TableBody>
               </Table>
             </ScrollArea>

--- a/app/components/procurement-form/details-section.tsx
+++ b/app/components/procurement-form/details-section.tsx
@@ -23,6 +23,12 @@ import { CalendarIcon, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ProcurementFullFormValues } from "@/app/stores/procurement-form";
 
+const lotNoDisplayMapping: { [key: number]: string } = {
+  1: "1 (High Quality)",
+  2: "2 (Moderate Quality)",
+  3: "3 (Low Quality)",
+};
+
 export function DetailsSection() {
   const {
     control,
@@ -130,7 +136,7 @@ export function DetailsSection() {
                   <SelectContent>
                     {[1, 2, 3].map((num) => (
                       <SelectItem key={num} value={num.toString()}>
-                        {num}
+                        {lotNoDisplayMapping[num]}{" "}
                       </SelectItem>
                     ))}
                   </SelectContent>


### PR DESCRIPTION
In procurements:
- added the text for Lot Numbers in the dropdown 1 (High Quality), 2 (Moderate Quality), 3 (Low Quality)

In processing:
- at the initial criteria selection, the processMethod for both the options "wet" and "dry", only "wet" was being taken. Fixed that, so now each item gives its corresponding value correctly